### PR TITLE
switch to custom build steps for demo

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -63,6 +63,14 @@ jobs:
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
+    # Discover where the MSBuild tool is and automatically add it to the PATH environment variable
+    - name: Setup MSBuild
+      uses: microsoft/setup-msbuild@v1
+
+    # Download/installs a given version of NuGet.exe. Using this action will add nuget to your $PATH
+    - name: Setup NuGet
+      uses: NuGet/setup-nuget@v1
+
     - name: Build
       run: |
         nuget restore FullDotNetWebApp.sln


### PR DESCRIPTION
NOTE: this repo is .NET framework so we are using `runs-on: windows-latest` runners that have .NET framework [on their list of pre-installed software](https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md)

Need to call setup-msbuild and setup-nuget so that tools are installed on PATH
- see [docs](https://github.com/advanced-security/advanced-security-material/blob/main/troubleshooting/codeql-builds/compiled-languages-csharp.md#net-framework)
```
     | The term 'msbuild' is not recognized as a name of a cmdlet, function, script file, or executable program. Check
     | the spelling of the name, or if a path was included, verify that the path is correct and try again.
```

yaml:
```
    # Discover where the MSBuild tool is and automatically add it to the PATH environment variable
    - name: Setup MSBuild
      uses: microsoft/setup-msbuild@v1

    # Download/installs a given version of NuGet.exe. Using this action will add nuget to your $PATH
    - name: Setup NuGet
      uses: NuGet/setup-nuget@v1


    - name: Build
      run: |
        nuget restore FullDotNetWebApp.sln
        msbuild FullDotNetWebApp.sln
```